### PR TITLE
Revert "chore(deps): bump slf4jVersion from 1.7.36 to 2.0.7"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ ext {
     avroConverterVersion = "7.2.2"
     aivenConnectCommonsVersion = "0.10.1"
 
-    slf4jVersion = "2.0.7"
+    slf4jVersion = "1.7.36"
 
     testcontainersVersion = "1.18.3"
     wireMockVersion = "2.35.0"


### PR DESCRIPTION
This reverts commit 2efe63bea7904a83eadd2df0c363f0d5bf1745d8.

See https://github.com/Aiven-Open/opensearch-connector-for-apache-kafka/pull/219#issuecomment-1651850483